### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,4 +1,6 @@
 name: PR Check
+permissions:
+  contents: read
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/interrogate-io/interrogate/security/code-scanning/1](https://github.com/interrogate-io/interrogate/security/code-scanning/1)

To fix the problem, we should explicitly add a `permissions` block with the least privileges necessary. Analysis of the workflow shows it merely checks out code, installs dependencies, runs build, lint, typecheck, some tests, and performs a SonarQube scan. None of these steps require write access to the repository, only read access to the code (contents). Therefore, adding `permissions: contents: read` at the workflow's root will suffice, covering all jobs unless a future job requires elevated access.  
Edit the `.github/workflows/pr.yml` file:  
- Add the following YAML block after the `name` line and before the `on` line:
  ```
  permissions:
    contents: read
  ```
No other code, tool, or library changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
