### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,4 +1,6 @@
 name: Publish Docker
+permissions:
+  contents: read
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/interrogate-io/interrogate/security/code-scanning/2](https://github.com/interrogate-io/interrogate/security/code-scanning/2)

The best fix is to add a `permissions` block at the root of the workflow (`.github/workflows/publish-docker.yml`) to fully restrict the default permissions of the `GITHUB_TOKEN`. Since this workflow only needs to checkout code (and that is using a PAT, not the GITHUB_TOKEN), setting `contents: read` (minimum) is adequate and follows least privilege. You should add:

```yaml
permissions:
  contents: read
```

after the workflow name (line 1) and before the `on:` block (line 2). This ensures all jobs in the workflow default to this minimal permission set, unless further permissions are specifically needed and specified.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
